### PR TITLE
Fix uninitialised `errno` causing erroneous termination in `openHive()`

### DIFF
--- a/ntreg.c
+++ b/ntreg.c
@@ -4230,6 +4230,8 @@ struct hive *openHive(char *filename, int mode)
 
   ALLOC(hdesc->buffer,1,hdesc->size);
 
+  errno = 0;
+
   rt = 0;
   do {  /* On some platforms read may not block, and read in chunks. handle that */
     r = read(hdesc->filedesc, hdesc->buffer + rt, hdesc->size - rt);


### PR DESCRIPTION
This resolves #3.